### PR TITLE
Conditionally delete active alerts for endpoints no longer tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ If the environment variable `SUMMARY_ENABLED` is "True", Cupcake will emit a sum
 | SLEEP_SECONDS              | Number of seconds to yield between runs                                  | 60                             |
 | ENDPOINT_DEFINITIONS_FILE  | Full path or S3 URL of endpoint definitions file                         | /opt/app/config/endpoints.json |
 | ALERT_DEFINITIONS_FILE     | Full path or S3 URL of alert definitions file                            | /opt/app/config/alerts.json    |
-| METRICS_DEFINITIONS_FILE   | Full path or S3 URL of metrics defintions file                           | /opt/app/config/metrics.json   |
+| METRICS_DEFINITIONS_FILE   | Full path or S3 URL of metrics definitions file                          | /opt/app/config/metrics.json   |
 | CONNECTION_TIMEOUT_SECONDS | Number of seconds before HTTP(S) and TCP connections will timeout        | 10                             |
 | DB_TYPE                    | Type of database to use. Possible values: `sqlite` or `postgresql`       | sqlite                         |
 | SUMMARY_ENABLED            | Whether to emit a summary / digest message to a subset of alert channels | True                           |
 | SUMMARY_SLEEP_SECONDS      | Number of seconds between emitting summary digests                       | 86400                          |
+| REMOVE_UNKNOWN_ACTIVES     | Whether to delete active alerts that are no longer present in alert defs | False                          |
 
 Note:
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -16,6 +16,7 @@ SUMMARY_SLEEP_SECONDS = int(os.getenv("SUMMARY_SLEEP_SECONDS"))
 METRICS_DEFINITIONS_FILE = os.getenv("METRICS_DEFINITIONS_FILE")
 MAX_WORKERS = int(os.getenv("MAX_WORKERS", default="2"))
 SHOW_BODY_IN_DEBUG_ON_UNEXPECTED_STATUS = bool(distutils.util.strtobool(os.getenv("SHOW_BODY_IN_DEBUG_ON_UNEXPECTED_STATUS", "False")))
+REMOVE_UNKNOWN_ACTIVES = bool(distutils.util.strtobool(os.getenv("REMOVE_UNKNOWN_ACTIVES", "False")))
 
 def get_database():
   if DB_TYPE == "postgresql":


### PR DESCRIPTION
PR to delete `active` DB records during summary generation if the endpoint in alert is no longer in the endpoints.json file. 

This avoids repeated alerts in summary message for endpoints that are no longer tracked.

Added env var, `REMOVE_UNKNOWN_ACTIVES` to enable this functionality. Logic is:

* When iterating through the endpoints in endpoint file, create `monitored` list containing string representatino of each endpoint (`"{environment_group}|{environment}|{endpoint_group}|{endpoint}|{active}"`)
* When processing active alerts, and if `REMOVE_UNKNOWN_ACTIVES=true`, check if string representation of endpoint in alert state is in the above `monitored` list. If so, business as usual.
* else, delete active record from db. 